### PR TITLE
rack.rb line for .map files in bower

### DIFF
--- a/config/initializers/rack.rb
+++ b/config/initializers/rack.rb
@@ -1,0 +1,1 @@
+Rack::Mime::MIME_TYPES.merge!({".map" => "text/plain"})


### PR DESCRIPTION
This is all good for being merged -- fix related to .map files in bower includes, and `rake assets:precompile` -- see https://github.com/FortAwesome/Font-Awesome/issues/6820#issuecomment-195950693.