### PR TITLE
per-image download button status indicator, close #217

### DIFF
--- a/app/assets/javascripts/mapknitter/Map.js
+++ b/app/assets/javascripts/mapknitter/Map.js
@@ -49,6 +49,8 @@ MapKnitter.Map = MapKnitter.Class.extend({
 
           downloadEl.click(function() { 
 
+            downloadEl.html("<i class='fa fa-circle-o-notch fa-spin'></i>");
+
             imgEl[0].onload = function() {
 
               var height = imgEl.height(),
@@ -78,6 +80,8 @@ MapKnitter.Map = MapKnitter.Class.extend({
                 [ nw.x, nw.y,  ne.x,  ne.y, se.x,  se.y,   sw.x, sw.y ],
                 true // trigger download
               ) 
+
+              downloadEl.html("<i class='fa fa-download'></i>");
 
             }
 

--- a/app/views/maps/_sidebar_exports.html.erb
+++ b/app/views/maps/_sidebar_exports.html.erb
@@ -1,5 +1,11 @@
 <p>
-  Export maps to generate downloadable, printable, high-resolution files. <a onClick="$('#exporting-info').toggle();">Learn more &raquo;</a>
+  Export maps to generate downloadable, printable, high-resolution files. 
+</p>
+<p>
+  If you only need one or two images, consider using the new <a href="https://publiclab.org/wiki/mapknitter-exporting-your-map#Per-image+exporting">per-image download</a> in the Images pane; to download a single full-resolution distorted image, click the <code><i class='fa fa-download'></i></code> button next to the image.
+</p>
+<p>
+  <a onClick="$('#exporting-info').toggle();">Learn more about exporting &raquo;</a>
 </p>
 <div style="display:none;" id="exporting-info"> 
   <p>From this panel you can export this map in a variety of formats. If you've changed the map at all since last exporting, you can re-run the export, but be aware that this will <b>delete and replace previously exported files</b>, so download them first if you want them. All formats are generated sequentially, so if you're waiting for a JPG you will have to let all the other formats complete first.</p>


### PR DESCRIPTION
* [x] tests pass -- `rake test`
* [x] code has been rebased on top of latest master (check if another pull request was added recently, and please rebase)
* [x] pull request is descriptively named and, if possible, multiple commits squashed if they're smaller changes