### PR TITLE
Replace ftools for fileutils (ftools is deprecated)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,16 +99,6 @@ You'll need at least Ruby v1.9.3 (**v2.1.x** preferred)
 7. Install static assets (like external javascript libraries, fonts) with `bower install` 
 8. Start rails with `bundle exec passenger start` from the Rails root and open http://localhost:3000 in a web browser. (For some, just `passenger start` will work; adding `bundle exec` ensures you're using the version of passenger you just installed with Bundler.)
 
-**Note:** If you are having problems exporting from the app, it may be that your Ruby version is not working well with ftools. In that case, remove the following lines in `warpable.rb`:
-
-    #require "ftools"
-    #File.copy(Rails.root.to_s+'/public'+self.image.to_s,local_location)
-
-And replace with:
-
-    require "fileutils"
-    FileUtils.cp(Rails.root.to_s+'/public'+self.image.to_s,local_location)
-
 ##Bugs and support
 
 To report bugs and request features, please use the GitHub issue tracker provided at https://github.com/publiclab/mapknitter/issues 

--- a/app/models/warpable.rb
+++ b/app/models/warpable.rb
@@ -205,8 +205,8 @@ class Warpable < ActiveRecord::Base
         }
       }
     else
-      require "ftools"
-      File.copy(Rails.root.to_s+'/public'+self.image.to_s,local_location)
+      require "fileutils"
+      FileUtils.cp(Rails.root.to_s+'/public'+self.image.to_s,local_location)
     end
 
     points = ""


### PR DESCRIPTION
Make sure these boxes are checked before your pull request is ready to be reviewed and merged. Thanks!

* [x] tests pass -- `rake test` (tested in production)
* [x] code has been rebased on top of latest master (check if another pull request was added recently, and please rebase)
* [x] pull request is descriptively named and, if possible, multiple commits squashed if they're smaller changes

Thanks!

ftools has been deprecated since Ruby 1.9.1