### PR TITLE
Contribute Dockerfile for working within a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Dockerfile # Mapknitter
+# https://github.com/publiclab/mapknitter/
+
+FROM ruby:2.1.2
+MAINTAINER Sebastian Silva "sebastian@fuentelibre.org"
+
+LABEL "This image deploys Mapknitter!"
+
+# Set correct environment variables.
+RUN mkdir -p /app
+ENV HOME /root
+
+# Install dependencies
+RUN apt-get update -qq && apt-get install -y bundler libmysqlclient-dev ruby-rmagick libfreeimage3 libfreeimage-dev ruby-dev gdal-bin python-gdal curl libcurl4-openssl-dev libssl-dev zip nodejs-legacy npm ##ALSO TRIED: ruby-pg
+RUN npm install -g bower
+
+# Install bundle of gems
+WORKDIR /tmp
+ADD Gemfile /tmp/Gemfile
+ADD Gemfile.lock /tmp/Gemfile.lock
+RUN bundle install
+
+# Add the Rails app
+WORKDIR /app
+ADD . /app
+RUN bower install --allow-root


### PR DESCRIPTION
This is the Dockerfile used to deploy Mapknitter locally.

For the record, some hacky tweaks were done to avoid using S3 in local production environment:
https://github.com/icarito/mapknitter/commit/19e0d38dce5b56584c7887ad66abca24dbedca2e

These could moved into configuration to allow friendlier local installation.
