### PR TITLE
Fix navbar medium screen sizes collapse behavior + change color

### DIFF
--- a/app/assets/stylesheets/header.css.scss
+++ b/app/assets/stylesheets/header.css.scss
@@ -1,1 +1,50 @@
-body { padding-top: 65px; }
+body {
+  padding-top: 60px;
+}
+
+/* override Bootstrap 3 navbar collapse for medium screen sizes */
+@media (max-width: 1200px) {
+  .navbar-header {
+    float: none;
+  }
+
+  .navbar-left,.navbar-right {
+    float: none !important;
+  }
+
+  .navbar-toggle {
+    display: block;
+  }
+
+  .navbar-collapse {
+    border-top: 1px solid transparent;
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.1);
+  }
+
+  .navbar-fixed-top {
+    top: 0;
+    border-width: 0 0 1px;
+  }
+
+  .navbar-collapse.collapse {
+    display: none !important;
+  }
+
+  .navbar-nav {
+    float: none !important;
+    margin-top: 7.5px;
+  }
+
+  .navbar-nav > li {
+    float: none;
+  }
+
+  .navbar-nav > li > a {
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+
+  .collapse.in{
+    display:block !important;
+  }
+}

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-default navbar-inverse navbar-fixed-top" role="navigation">
+<nav class="navbar navbar-default navbar-fixed-top" role="navigation">
   <div class="container-fluid">
     <div class="navbar-header">
       <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar-collapse">


### PR DESCRIPTION
Bootstrap 3 has a different media query for collapsing the navbar and I just noticed that after @sashadev-sky mentioned that (thanks!). So I added some CSS properties to fix this. I changed the color to the previous one as well, but I didn't re-add the logo because we have some UI improvements to be made soon, so I thought it could wait before re-adding this back.

Also, I tested with the alerts improvement from #383 and it looks like it's okay now:


![Screenshot_2019-03-12 MapKnitter](https://user-images.githubusercontent.com/10670581/54244164-9dad6a00-44e8-11e9-94f2-d087b1997199.png)
![Screen Shot 2019-03-12 at 16 54 49](https://user-images.githubusercontent.com/10670581/54244168-a00fc400-44e8-11e9-9350-54ee5260afef.png)


