### PR TITLE
Set up Coveralls

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,2 +1,2 @@
 service_name: travis-ci
-repo_token: <%= ENV["REPO_TOKEN"] %>
+repo_token: ${REPO_TOKEN}

--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,2 @@
+service_name: travis-ci
+repo_token: <%= ENV["REPO_TOKEN"] %>

--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,2 +1,2 @@
 service_name: travis-ci
-repo_token: ${REPO_TOKEN}
+repo_token: REPO_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,5 @@ install:
   - docker-compose run web bower install --allow-root
 
 script:
+  - sed -ri "s/REPO_TOKEN/$REPO_TOKEN/" .coveralls.yml
   - docker-compose run web bash -l -c "CI=true TRAVIS=true rake test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ install:
   - docker-compose run web bower install --allow-root
 
 script:
-  - docker-compose run web bash -l -c "rake test"
+  - docker-compose run web bash -l -c "CI=true TRAVIS=true rake test"

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ group :dependencies do
   gem "ruby-openid", "~>2.5"
   gem "open_id_authentication"
   gem "RubyInline"
+  gem "coveralls", required: false
   gem "paperclip", "~>4.2.2"
 
   # if you use amazon s3 for warpable image storage

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ group :dependencies do
   gem "ruby-openid", "~>2.5"
   gem "open_id_authentication"
   gem "RubyInline"
-  gem "coveralls", required: false
+  gem "coveralls", require: false
   gem "paperclip", "~>4.2.2"
 
   # if you use amazon s3 for warpable image storage

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ## MapKnitter 2
+[![Coverage Status](https://coveralls.io/repos/github/kaunair/mapknitter/badge.svg?branch=%28HEAD+detached+at+3dd0c43%29)](https://coveralls.io/github/kaunair/mapknitter?branch=%28HEAD+detached+at+3dd0c43%29)
 
 Use Public Lab's open source MapKnitter to upload your own aerial photographs (for example those from balloon or kite mapping: http://publiclab.org/balloon-mapping) and combine them into:
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+require 'coveralls'
+Coveralls.wear!('rails')
 ENV["RAILS_ENV"] = "test"
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'


### PR DESCRIPTION
I couldn't get it to work without the repo token, but it is supposed to work of oss projects. I'm not sure why this is happening? :confused: 
Also coveralls.yml doesn't detect the env variables from travis ([Check this build](https://travis-ci.org/kaunair/mapknitter/builds/509782397)) So I had to manually replace the repo token using sed
All you need to do now is set up the REPO_TOKEN env variable in the travis settings page.
[You can check out the working version on my fork!](https://github.com/kaunair/mapknitter/pull/3)
Cheers!


![image](https://user-images.githubusercontent.com/30197132/54807239-a2b9a880-4ca2-11e9-9584-99d959240750.png)
