### PR TITLE
Change comment count on comment creation via AJAX #441

### DIFF
--- a/app/assets/javascripts/maps.js
+++ b/app/assets/javascripts/maps.js
@@ -58,6 +58,7 @@ jQuery(document).ready(function($) {
     $("#new_comment textarea").val('')
 
     $("#comments").append(xhr.responseText)
+    $("#comments-number").text(function(i, str) { return (parseInt(str) + 1); });
     $('.comment:last').click(edit_comment).click(delete_comment)
   }).on("ajax:error", function(e, xhr, status, error) {
     if (xhr.responseText == "Login required.") {


### PR DESCRIPTION
This closes issue #441 "Change comment count on comment creation via AJAX #441" by incrementing comments-number each time a new comment is added. This would ensure that the counter indicating the number of comments is increased without needing to refresh the page.

To test it: 
1. Visit https://mapknitter.org/maps/test-map-1
2. Add a new comment
3. "0 comments" should change to "1 comments" without needing to refresh the page