### PR TITLE
Roll back to using Debian 9 with custom built GDAL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,11 @@ ENV HOME /root
 
 # Install dependencies
 RUN apt-get update -qq && apt-get install -y \
-  nodejs gdal-bin curl procps git imagemagick python-gdal zip
+  nodejs gdal-bin curl procps git imagemagick python-gdal zip python-pip
 
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && apt-get install -y npm
 RUN npm install -g bower
+RUN pip install --upgrade GDAL
 
 # Install bundle of gems
 SHELL [ "/bin/bash", "-l", "-c" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV HOME /root
 
 # Install dependencies
 RUN apt-get update -qq && apt-get install -y \
-  nodejs gdal-bin curl procps git imagemagick python-gdal
+  nodejs gdal-bin curl procps git imagemagick python-gdal zip
 
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && apt-get install -y npm
 RUN npm install -g bower

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV HOME /root
 
 # Install dependencies
 RUN apt-get update -qq && apt-get install -y \
-  nodejs gdal-bin curl procps git imagemagick
+  nodejs gdal-bin curl procps git imagemagick python-gdal
 
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && apt-get install -y npm
 RUN npm install -g bower

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV HOME /root
 
 # Install dependencies
 RUN apt-get update -qq && apt-get install -y \
-  nodejs gdal-bin curl procps git imagemagick python-gdal zip python-pip
+  nodejs gdal-bin curl procps git imagemagick python-gdal zip python-pip libgdal-dev
 
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && apt-get install -y npm
 RUN npm install -g bower

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,12 @@ FROM ruby:2.4.6-stretch
 # Set correct environment variables.
 ENV HOME /root
 
+# Backported GDAL
 RUN echo "deb http://packages.laboratoriopublico.org/publiclab/ stretch main" > /etc/apt/sources.list.d/publiclab.list
+
+# Obtain key
+RUN mkdir ~/.gnupg
+RUN echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf
 RUN apt-key adv --keyserver hkps.pool.sks-keyservers.net --recv-keys BF26EE05EA6A68F0
 
 # Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,30 +2,17 @@
 # https://github.com/publiclab/mapknitter/
 # This image deploys Mapknitter!
 
-FROM debian:stretch
+FROM ruby:2.4-stretch
 
 # Set correct environment variables.
 ENV HOME /root
 
 # Install dependencies
 RUN apt-get update -qq && apt-get install -y \
-  bundler ruby-rmagick libfreeimage3 \
-  libfreeimage-dev zip nodejs gdal-bin \
-  curl g++ gcc autoconf automake bison \
-  libc6-dev libffi-dev libgdbm-dev \
-  libncurses5-dev libsqlite3-dev libtool \
-  libyaml-dev make pkg-config sqlite3 \
-  zlib1g-dev libgmp-dev libreadline-dev libssl-dev \
-  procps libmariadb-dev-compat libmariadb-dev git python-gdal \
-  imagemagick
-
-# Ruby
-RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB && curl -sSL https://get.rvm.io | bash -s stable && usermod -a -G rvm root
-RUN /bin/bash -l -c ". /etc/profile.d/rvm.sh && rvm install 2.4.4 && rvm use 2.4.4 --default"
+  nodejs gdal-bin curl procps git imagemagick
 
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && apt-get install -y npm
 RUN npm install -g bower
-
 
 # Install bundle of gems
 SHELL [ "/bin/bash", "-l", "-c" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # https://github.com/publiclab/mapknitter/
 # This image deploys Mapknitter!
 
-FROM debian:buster
+FROM debian:stretch
 
 # Set correct environment variables.
 ENV HOME /root
@@ -33,9 +33,6 @@ WORKDIR /tmp
 ADD Gemfile /tmp/Gemfile
 ADD Gemfile.lock /tmp/Gemfile.lock
 RUN bundle install
-
-# HOTFIX Workaround for mysql2 gem incompatibility with libmariadb-dev
-RUN sed -i "s/ LONG_PASSWORD |//g" /usr/local/rvm/gems/ruby-*/gems/mysql2-*/lib/mysql2/client.rb
 
 # Add the Rails app
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,10 @@ ENV HOME /root
 
 # Install dependencies
 RUN apt-get update -qq && apt-get install -y \
-  nodejs gdal-bin curl procps git imagemagick python-gdal zip python-pip libgdal-dev
+  nodejs gdal-bin curl procps git imagemagick python-gdal zip
 
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && apt-get install -y npm
 RUN npm install -g bower
-RUN pip install --upgrade GDAL
 
 # Install bundle of gems
 SHELL [ "/bin/bash", "-l", "-c" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # https://github.com/publiclab/mapknitter/
 # This image deploys Mapknitter!
 
-FROM ruby:2.4-stretch
+FROM ruby:2.4.6-stretch
 
 # Set correct environment variables.
 ENV HOME /root

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ FROM ruby:2.4.6-stretch
 # Set correct environment variables.
 ENV HOME /root
 
+RUN echo "deb http://packages.laboratoriopublico.org/publiclab/ stretch main" > /etc/apt/sources.list.d/publiclab.list
+RUN apt-key adv --keyserver hkps.pool.sks-keyservers.net --recv-keys BF26EE05EA6A68F0
+
 # Install dependencies
 RUN apt-get update -qq && apt-get install -y \
   nodejs gdal-bin curl procps git imagemagick python-gdal zip

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby "2.4.4"
+ruby "2.4.6"
 gem "rails", "~>3.2"
 gem 'rake',  '~> 12.3.2'
 

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ export COMPOSE_HTTP_TIMEOUT=360
 
 build:
 	cp config/database.yml.example config/database.yml
+	cp config/amazon_s3.yml.example config/amazon_s3.yml
 	cp db/schema.rb.example db/schema.rb
 	docker-compose build
 

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,10 @@ build:
 	cp config/database.yml.example config/database.yml
 	cp db/schema.rb.example db/schema.rb
 	docker-compose build
-	docker-compose run --rm web bash -l -c "sleep 10 && bower install --allow-root && rake db:setup && rake db:migrate && rake assets:precompile"
 
 deploy-container:
 	docker-compose up -d
+	docker-compose exec -T web bash -l -c "sleep 10 && rake db:setup && rake db:migrate && rake assets:precompile"
 
 redeploy-container:
 	docker-compose up --force-recreate -d

--- a/README.md
+++ b/README.md
@@ -116,3 +116,6 @@ Help improve Public Lab software!
 * Review contributor guidelines at http://publiclab.org/wiki/contributing-to-public-lab-software
 * Some devs hang out in http://publiclab.org/chat (irc webchat)
 
+## Staging infrastructure and testing
+
+In addition automatic testing with Travis CI - we have a branch (`unstable`) is set to auto-build and deploy to [a staging instance](http://mapknitter-unstable.laboratoriopublico.org/). This instance includes a copy of the production database and is intended for experimenting or debugging purposes with a production-like environment.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,12 @@
 version: '3.3'
 services:
   db:
-    container_name: db
     image: mysql:5.7
     env_file:
       - mapknitter.env
     volumes:
       - ../mysql:/var/lib/mysql
   web:
-    container_name: web
     build: .
     env_file:
       - mapknitter.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       - mapknitter.env
     volumes:
       - ../mysql:/var/lib/mysql
+      - ../dump:/docker-entrypoint-initdb.d
   web:
     build: .
     env_file:


### PR DESCRIPTION
Here I've rolled back the upgrade to Debian 10 / Buster because the Mysql Gem was having issues with libmariadb-dev. I had to backport Debian 10 packages of GDAL 2.4 but it seems to work much faster now!

Also this PR contains tweaks that are needed for building `unstable` branch as staging for the team to use for testing.

[//]: # (To mark checkboxe write 'x' within the square brackets)

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
