### PR TITLE
Choose keyserver known to have our GPG key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN echo "deb http://packages.laboratoriopublico.org/publiclab/ stretch main" > 
 # Obtain key
 RUN mkdir ~/.gnupg
 RUN echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf
-RUN apt-key adv --keyserver hkps.pool.sks-keyservers.net --recv-keys BF26EE05EA6A68F0
+RUN apt-key adv --keyserver fks.pgpkeys.eu --recv-keys BF26EE05EA6A68F0
 
 # Install dependencies
 RUN apt-get update -qq && apt-get install -y \


### PR DESCRIPTION
Fixes recent build unreliability.

This should work around slow key distribution and make builds reliable again!

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

[//]: # (To mark checkboxe write 'x' within the square brackets)

* [ ] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [ ] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
