### PR TITLE
Fix rubocop offenses for controllers

### DIFF
--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 
 class AnnotationsController < ApplicationController
@@ -5,31 +7,29 @@ class AnnotationsController < ApplicationController
   before_filter :find_map
 
   def index
-    render :file => 'annotations/index.json.erb', :content_type => 'application/json'
+    render file: 'annotations/index.json.erb', content_type: 'application/json'
   end
 
   def create
     geojson = params[:annotation]
 
     respond_to do |format|
-      format.json {
+      format.json do
         @annotation = @map.annotations.create(
-          :annotation_type => geojson[:properties][:annotation_type],
-          :coordinates => geojson[:geometry][:coordinates],
-          :text => geojson[:properties][:textContent],
-          :style => geojson[:properties][:style],
+          annotation_type: geojson[:properties][:annotation_type],
+          coordinates: geojson[:geometry][:coordinates],
+          text: geojson[:properties][:textContent],
+          style: geojson[:properties][:style]
         )
         @annotation.user_id = current_user.id if logged_in?
-        if @annotation.save
-          redirect_to map_annotation_url(@map, @annotation)
-        end
-      }
+        redirect_to map_annotation_url(@map, @annotation) if @annotation.save
+      end
     end
   end
 
   def show
     @annotation = Annotation.find params[:id]
-    render :file => 'annotations/show.json.erb', :content_type => 'application/json'
+    render file: 'annotations/show.json.erb', content_type: 'application/json'
   end
 
   def update
@@ -37,10 +37,10 @@ class AnnotationsController < ApplicationController
     geojson = params[:annotation]
     if @annotation.user_id.nil? || current_user.can_edit?(@annotation)
       Annotation.update(@annotation.id,
-                        :coordinates => geojson[:geometry][:coordinates],
-                        :text => geojson[:properties][:textContent],
-                        :style => geojson[:properties][:style])
-      render :file => 'annotations/update.json.erb', :content_type => 'application/json'
+                        coordinates: geojson[:geometry][:coordinates],
+                        text: geojson[:properties][:textContent],
+                        style: geojson[:properties][:style])
+      render file: 'annotations/update.json.erb', content_type: 'application/json'
     end
   end
 

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -12,7 +12,7 @@ class AnnotationsController < ApplicationController
     geojson = params[:annotation]
 
     respond_to do |format|
-      format.json { 
+      format.json {
         @annotation = @map.annotations.create(
           :annotation_type => geojson[:properties][:annotation_type],
           :coordinates => geojson[:geometry][:coordinates],
@@ -37,24 +37,22 @@ class AnnotationsController < ApplicationController
     geojson = params[:annotation]
     if @annotation.user_id.nil? || current_user.can_edit?(@annotation)
       Annotation.update(@annotation.id,
-        :coordinates => geojson[:geometry][:coordinates],
-        :text => geojson[:properties][:textContent],
-        :style => geojson[:properties][:style]
-      )
+                        :coordinates => geojson[:geometry][:coordinates],
+                        :text => geojson[:properties][:textContent],
+                        :style => geojson[:properties][:style])
       render :file => 'annotations/update.json.erb', :content_type => 'application/json'
     end
-  end  
+  end
 
   def destroy
     @annotation = Annotation.find params[:id]
     # if current_user.can_delete?(@annotation)
-      @annotation.delete 
-      head :ok
+    @annotation.delete
+    head :ok
     # end
   end
 
   def find_map
     @map = Map.find params[:map_id]
   end
-
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  #include OpenIdAuthentication # shouldn't be necessary!!
+  # include OpenIdAuthentication # shouldn't be necessary!!
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
@@ -10,7 +10,7 @@ class ApplicationController < ActionController::Base
   helper_method :logged_in?
 
   def current_user
-    user_id = session[:user_id] 
+    user_id = session[:user_id]
     if user_id
       begin
         @user = User.find(user_id)
@@ -24,26 +24,25 @@ class ApplicationController < ActionController::Base
 
   private
 
-    def require_login
-      unless logged_in?
-        path_info = request.env['PATH_INFO']
-        flash[:warning] = "You must be logged in to access this section"
-        redirect_to '/login?back_to=' + path_info.to_param # halts request cycle
-      end
+  def require_login
+    unless logged_in?
+      path_info = request.env['PATH_INFO']
+      flash[:warning] = "You must be logged in to access this section"
+      redirect_to '/login?back_to=' + path_info.to_param # halts request cycle
     end
+  end
 
-    def logged_in?
-      user_id = session[:user_id]
+  def logged_in?
+    user_id = session[:user_id]
 
-      begin
-        if user_id and User.find(user_id)
-          return true
-        else
-          return false
-        end
-      rescue
+    begin
+      if user_id and User.find(user_id)
+        return true
+      else
         return false
       end
+    rescue
+      return false
     end
-
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationController < ActionController::Base
   # include OpenIdAuthentication # shouldn't be necessary!!
   # Prevent CSRF attacks by raising an exception.
@@ -14,7 +16,7 @@ class ApplicationController < ActionController::Base
     if user_id
       begin
         @user = User.find(user_id)
-      rescue
+      rescue StandardError
         @user = nil
       end
     else
@@ -27,7 +29,7 @@ class ApplicationController < ActionController::Base
   def require_login
     unless logged_in?
       path_info = request.env['PATH_INFO']
-      flash[:warning] = "You must be logged in to access this section"
+      flash[:warning] = 'You must be logged in to access this section'
       redirect_to '/login?back_to=' + path_info.to_param # halts request cycle
     end
   end
@@ -36,12 +38,12 @@ class ApplicationController < ActionController::Base
     user_id = session[:user_id]
 
     begin
-      if user_id and User.find(user_id)
+      if user_id && User.find(user_id)
         return true
       else
         return false
       end
-    rescue
+    rescue StandardError
       return false
     end
   end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,33 +1,34 @@
-class CommentsController < ApplicationController
+# frozen_string_literal: true
 
+class CommentsController < ApplicationController
   def create
     if logged_in?
       @map = Map.find params[:map_id]
 
       @comment = @map.comments.new(
-        :user_id => current_user.id,
-        :body => params[:comment][:body]
+        user_id: current_user.id,
+        body: params[:comment][:body]
       )
       if @comment.save!
         users = @map.comments.collect(&:user)
         users += [@map.user] unless @map.user.nil?
         users.uniq.each do |user|
           unless user.id == current_user.id
-            CommentMailer.notify(user,@comment).deliver
+            CommentMailer.notify(user, @comment).deliver
           end
         end
       end
 
       respond_to do |format|
-        #format.html { redirect_to "/maps/" + params[:map_id] }
-        format.html   { render :partial => 'comments/comment', :locals => {:comment => @comment} }
-        #format.js   { render :partial => 'comments/comment', :locals => {:comment => @comment} }
+        # format.html { redirect_to "/maps/" + params[:map_id] }
+        format.html   { render partial: 'comments/comment', locals: { comment: @comment } }
+        # format.js   { render :partial => 'comments/comment', :locals => {:comment => @comment} }
         format.json { render json: @comment, status: :created }
       end
-     
+
     else
       # we intercept this message in /app/assets/javascripts/maps.js
-      render :text => "Login required."
+      render text: 'Login required.'
     end
   end
 
@@ -35,10 +36,10 @@ class CommentsController < ApplicationController
     @comment = Comment.find params[:id]
     if logged_in? && current_user.can_edit?(@comment)
       @comment.update_attribute(:body, params[:comment][:body])
-      redirect_to "/maps/" + params[:map_id]
+      redirect_to '/maps/' + params[:map_id]
     else
-      flash[:error] = "You do not have permissions to update that comment."
-      redirect_to "/login"            
+      flash[:error] = 'You do not have permissions to update that comment.'
+      redirect_to '/login'
     end
   end
 
@@ -46,10 +47,10 @@ class CommentsController < ApplicationController
     @comment = Comment.find(params[:id])
 
     if logged_in? && current_user.can_delete?(@comment)
-      @comment.delete 
-      flash[:notice] = "Comment deleted."
+      @comment.delete
+      flash[:notice] = 'Comment deleted.'
     else
-      flash[:error] = "You do not have permission to delete that comment."
+      flash[:error] = 'You do not have permission to delete that comment.'
     end
     redirect_to "/maps/#{params[:map_id]}"
   end

--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -1,15 +1,17 @@
+# frozen_string_literal: true
+
 class ExportController < ApplicationController
-  protect_from_forgery :except => [:formats]
+  protect_from_forgery except: [:formats]
 
   def index
-    @exports = Export.where('status NOT IN (?)',['failed','complete','none'])
-      .order('updated_at DESC')
-    @day = Export.where(status:'complete')
-      .where('updated_at > (?)',(Time.now-1.day).to_s(:db))
-      .count
-    @week = Export.where(status:'complete')
-      .where('updated_at > (?)',(Time.now-1.week).to_s(:db))
-      .count
+    @exports = Export.where('status NOT IN (?)', %w[failed complete none])
+                     .order('updated_at DESC')
+    @day = Export.where(status: 'complete')
+                 .where('updated_at > (?)', (Time.now - 1.day).to_s(:db))
+                 .count
+    @week = Export.where(status: 'complete')
+                  .where('updated_at > (?)', (Time.now - 1.week).to_s(:db))
+                  .count
   end
 
   # override logger to suppress huge amounts of inane /export/progress logging
@@ -23,47 +25,46 @@ class ExportController < ApplicationController
 
   # https://mapknitter.org/warps/yale-farm/yale-farm.jpg
   def jpg
-    send_file 'public/warps/'+params[:id]+'/'+params[:id]+'.jpg'
+    send_file 'public/warps/' + params[:id] + '/' + params[:id] + '.jpg'
   end
 
   # https://mapknitter.org/warps/yale-farm/yale-farm-geo.tif
   def geotiff
-    send_file 'public/warps/'+params[:id]+'/'+params[:id]+'-geo.tif'
+    send_file 'public/warps/' + params[:id] + '/' + params[:id] + '-geo.tif'
   end
 
   def cancel
-    @map = Map.find params[:id] 
+    @map = Map.find params[:id]
     if @map.anonymous? || logged_in?
       export = @map.export
       export.status = 'none'
       export.save
       if params[:exports]
-        flash[:notice] = "Export cancelled."
-        redirect_to "/exports"
+        flash[:notice] = 'Export cancelled.'
+        redirect_to '/exports'
       else
-        render :text => 'cancelled'
+        render text: 'cancelled'
       end
     else
-      render :text => 'You must be logged in to export, unless the map is anonymous.'
+      render text: 'You must be logged in to export, unless the map is anonymous.'
     end
   end
 
   def progress
-    map = Map.find params[:id] 
-    if export = map.export
-      if  export.status == 'complete'
-        output = 'complete'
-      elsif export.status == 'none'
-        output = 'export not running'
-      elsif export.status == 'failed'
-        output = 'export failed'
-      else
-        output = export.status
-      end
-    else
-      output = 'export has not been run'
-    end
-    render :text => output, :layout => false 
+    map = Map.find params[:id]
+    output = if export = map.export
+               if export.status == 'complete'
+                 'complete'
+               elsif export.status == 'none'
+                 'export not running'
+               elsif export.status == 'failed'
+                 'export failed'
+               else
+                 export.status
+                        end
+             else
+               'export has not been run'
+             end
+    render text: output, layout: false
   end
-
 end

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -1,56 +1,56 @@
-class FeedsController < ApplicationController
+# frozen_string_literal: true
 
+class FeedsController < ApplicationController
   def all
-    #(Warpable.all + Map.all).sort_by(&:created_at)
-    @maps = Map.find(:all, 
-      :order => "id DESC",:limit => 20, 
-      :conditions => {:archived => false, :password => ''},
-      :joins => [:user, :warpables], 
-      :group => "maps.id")
-    render :layout => false, :template => "feeds/all"
-    response.headers["Content-Type"] = "application/xml; charset=utf-8"
+    # (Warpable.all + Map.all).sort_by(&:created_at)
+    @maps = Map.find(:all,
+                     order: 'id DESC', limit: 20,
+                     conditions: { archived: false, password: '' },
+                     joins: %i[user warpables],
+                     group: 'maps.id')
+    render layout: false, template: 'feeds/all'
+    response.headers['Content-Type'] = 'application/xml; charset=utf-8'
   end
 
   def clean
     @maps = Map.order(id: :desc)
-      .limit(20)
-      .where(archived: false, password: '')
-      .joins(:warpables)
-      .group("maps.id")
-    render layout: false, template: "feeds/clean"
-    response.headers["Content-Type"] = "application/xml; charset=utf-8"
+               .limit(20)
+               .where(archived: false, password: '')
+               .joins(:warpables)
+               .group('maps.id')
+    render layout: false, template: 'feeds/clean'
+    response.headers['Content-Type'] = 'application/xml; charset=utf-8'
   end
 
   def license
-     @maps = Map.order(id: :desc)
-    .limit(20)
-    .where(archived: false, password: '', license: params[:id])
-    .joins(:warpables)
-    .group("maps.id")
-    render layout: false, template: "feeds/license"
-    response.headers["Content-Type"] = "application/xml; charset=utf-8"
+    @maps = Map.order(id: :desc)
+               .limit(20)
+               .where(archived: false, password: '', license: params[:id])
+               .joins(:warpables)
+               .group('maps.id')
+    render layout: false, template: 'feeds/license'
+    response.headers['Content-Type'] = 'application/xml; charset=utf-8'
   end
 
   def author
-    @maps = Map.find_all_by_author(params[:id],:order => "id DESC", :conditions => {:archived => false, :password => ''},:joins => :warpables, :group => "maps.id")
+    @maps = Map.find_all_by_author(params[:id], order: 'id DESC', conditions: { archived: false, password: '' }, joins: :warpables, group: 'maps.id')
     images = []
     @maps.each do |map|
-      images = images + map.warpables
+      images += map.warpables
     end
     @feed = (@maps + images).sort_by(&:created_at)
-    render :layout => false, :template => "feeds/author"
-    response.headers["Content-Type"] = "application/xml; charset=utf-8"
+    render layout: false, template: 'feeds/author'
+    response.headers['Content-Type'] = 'application/xml; charset=utf-8'
   end
 
   def tag
     @tag = Tag.find_by_name params[:id]
     if @tag
-      @maps = @tag.maps.paginate(:page => params[:page], :per_page => 24)
-      render :layout => false, :template => "feeds/tag"
-      response.headers["Content-Type"] = "application/xml; charset=utf-8"
+      @maps = @tag.maps.paginate(page: params[:page], per_page: 24)
+      render layout: false, template: 'feeds/tag'
+      response.headers['Content-Type'] = 'application/xml; charset=utf-8'
     else
       render text: "No maps with tag #{params[:id]}"
     end
   end
-
 end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -1,22 +1,24 @@
+# frozen_string_literal: true
+
 require 'open-uri'
 class ImagesController < ApplicationController
   # avoid raising exceptions for common errors (e.g. file not found)
-  rescue_from Errno::ENOENT, :with => :url_upload_not_found
-  rescue_from Errno::ETIMEDOUT, :with => :url_upload_not_found
-  rescue_from OpenURI::HTTPError, :with => :url_upload_not_found
-  rescue_from Timeout::Error, :with => :url_upload_not_found
-  protect_from_forgery :except => [:update,:delete]
-  #Convert model to json without including root name. Eg. 'warpable'
+  rescue_from Errno::ENOENT, with: :url_upload_not_found
+  rescue_from Errno::ETIMEDOUT, with: :url_upload_not_found
+  rescue_from OpenURI::HTTPError, with: :url_upload_not_found
+  rescue_from Timeout::Error, with: :url_upload_not_found
+  protect_from_forgery except: %i[update delete]
+  # Convert model to json without including root name. Eg. 'warpable'
   ActiveRecord::Base.include_root_in_json = false
 
-  # proxy, used if MapKnitter is being backed by Amazon S3 file storage, 
+  # proxy, used if MapKnitter is being backed by Amazon S3 file storage,
   # to enable client-side distortion using webgl-distort, which requires same-origin
   def fetch
     if Rails.env.production?
-      if params[:url][0..42] == "https://s3.amazonaws.com/grassrootsmapping/"
+      if params[:url][0..42] == 'https://s3.amazonaws.com/grassrootsmapping/'
         url = URI.parse(params[:url])
         result = Net::HTTP.get_response(url)
-        send_data result.body, :type => result.content_type, :disposition => 'inline'
+        send_data result.body, type: result.content_type, disposition: 'inline'
       end
     else
       redirect_to params[:url]
@@ -33,14 +35,14 @@ class ImagesController < ApplicationController
     map.save
     respond_to do |format|
       if @warpable.save
-        format.html {
-          render :json => [@warpable.fup_json].to_json,
-          :content_type => 'text/html'
-        }
-       format.json { render :json => {:files => [@warpable.fup_json]}, :status => :created, :location => @warpable.image.url }
+        format.html do
+          render json: [@warpable.fup_json].to_json,
+                 content_type: 'text/html'
+        end
+        format.json { render json: { files: [@warpable.fup_json] }, status: :created, location: @warpable.image.url }
       else
-       format.html { render :action => "new" }
-       format.json { render :json => {:files => [@warpable.fup_error_json]}, :layout => false}
+        format.html { render action: 'new' }
+        format.json { render json: { files: [@warpable.fup_error_json] }, layout: false }
       end
     end
   end
@@ -54,24 +56,24 @@ class ImagesController < ApplicationController
     map.updated_at = Time.now
     map.save
     if @warpable.save
-      redirect_to "/maps/"+params[:name]
+      redirect_to '/maps/' + params[:name]
     else
-      flash[:notice] = "Sorry, the image failed to import."
-      redirect_to "/map/edit/"+params[:name]
+      flash[:notice] = 'Sorry, the image failed to import.'
+      redirect_to '/map/edit/' + params[:name]
     end
   end
 
   # is this used?
   def url_upload_not_found
-    flash[:notice] = "Sorry, the URL you provided was not valid."
-    redirect_to "/map/edit/"+params[:id]
+    flash[:notice] = 'Sorry, the URL you provided was not valid.'
+    redirect_to '/map/edit/' + params[:id]
   end
 
   def show
     @image = Warpable.find params[:id]
     respond_to do |format|
       format.html # show.html.erb
-      format.json { render :json => @image.map{|img| img.fup_json} }
+      format.json { render json: @image.map { |img| img.fup_json } }
     end
   end
 
@@ -85,13 +87,13 @@ class ImagesController < ApplicationController
     params[:points].split(':').each do |point|
       lon = point.split(',')[0]
       lat = point.split(',')[1]
-      node = Node.new({
-                :color => 'black',
-                :lat => lat,
-                :lon => lon,
-                :author => author,
-                :name => ''
-      })
+      node = Node.new(
+        color: 'black',
+        lat: lat,
+        lon: lon,
+        author: author,
+        name: ''
+      )
       node.save
       nodes << node
     end
@@ -100,7 +102,7 @@ class ImagesController < ApplicationController
     @warpable.locked = params[:locked]
     @warpable.cm_per_pixel = @warpable.get_cm_per_pixel
     @warpable.save
-    render :text => 'success'
+    render text: 'success'
   end
 
   def destroy
@@ -109,11 +111,11 @@ class ImagesController < ApplicationController
       @warpable.destroy
       respond_to do |format|
         format.html { redirect_to @warpable.map }
-        format.json { render :json => @warpable }
+        format.json { render json: @warpable }
       end
     else
-      flash[:error] = "You must be logged in to delete images."
-      redirect_to "/login"
+      flash[:error] = 'You must be logged in to delete images.'
+      redirect_to '/login'
     end
   end
 end

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -10,13 +10,13 @@ class MapsController < ApplicationController
     # show only maps with at least 1 image to reduce spammer interest
     @maps = Map.page(params[:page])
                .per_page(20)
-	       .where(archived: false, password: '')
-	       .order('updated_at DESC')
+               .where(archived: false, password: '')
+               .order('updated_at DESC')
                .joins(:warpables)
-	       .group("maps.id")
+               .group("maps.id")
     # ensure even maps with no images are shown on front page and don't get lost; some spam risk
     @new_maps = Map.where(archived: false, password: '')
-	       .order('updated_at DESC')
+                   .order('updated_at DESC')
     render :layout => 'application'
   end
 
@@ -60,14 +60,14 @@ class MapsController < ApplicationController
     @map = Map.find params[:id]
     @map.zoom ||= 12
 
-    # stuff for Sparklines resolution graph; 
+    # stuff for Sparklines resolution graph;
     # messy, could tuck into model
-    #hist = @map.images_histogram 
-    #(0..100).each do |i|
+    # hist = @map.images_histogram
+    # (0..100).each do |i|
     # hist[i] = 0 if !hist[i]
-    #end
-    #hist = hist[0..100]
-    #@images_histogram = @map.grouped_images_histogram((hist.length/15).to_i+1)
+    # end
+    # hist = hist[0..100]
+    # @images_histogram = @map.grouped_images_histogram((hist.length/15).to_i+1)
 
     # this is used for the resolution slider
     @resolution = @map.average_cm_per_pixel.round(4)
@@ -160,7 +160,7 @@ class MapsController < ApplicationController
   def export
     map = Map.find params[:id]
     if logged_in? || Rails.env.development? || verify_recaptcha(:model => map, :message => "ReCAPTCHA thinks you're not a human!")
-      render :text => map.run_export(current_user,params[:resolution].to_f)
+      render :text => map.run_export(current_user, params[:resolution].to_f)
     else
       render :text => 'You must be logged in to export, unless the map is anonymous.'
     end
@@ -176,13 +176,13 @@ class MapsController < ApplicationController
   def region
     area = params[:id] || "this area"
     @title = "Maps in #{area}"
-    ids = Map.bbox(params[:minlat],params[:minlon],params[:maxlat],params[:maxlon]).collect(&:id)
-    @maps = Map.where(password: '').where('id IN (?)',ids).paginate(:page => params[:page], :per_page => 24).except(:styles)
+    ids = Map.bbox(params[:minlat], params[:minlon], params[:maxlat], params[:maxlon]).collect(&:id)
+    @maps = Map.where(password: '').where('id IN (?)', ids).paginate(:page => params[:page], :per_page => 24).except(:styles)
     @maps.each do |map|
-      map.image_urls = map.warpables.map{ |warpable| warpable.image.url}
+      map.image_urls = map.warpables.map { |warpable| warpable.image.url }
     end
     respond_to do |format|
-      format.html { render "maps/index", :layout => "application" } 
+      format.html { render "maps/index", :layout => "application" }
       format.json { render :json => @maps.to_json(methods: :image_urls) }
     end
   end
@@ -190,7 +190,7 @@ class MapsController < ApplicationController
   # list by license
   def license
     @title = "Maps licensed '#{params[:id]}'"
-    @maps = Map.where(password: '',license: params[:id]).order('updated_at DESC').paginate(:page => params[:page], :per_page => 24)
+    @maps = Map.where(password: '', license: params[:id]).order('updated_at DESC').paginate(:page => params[:page], :per_page => 24)
     render "maps/index", :layout => "application"
   end
 
@@ -202,12 +202,11 @@ class MapsController < ApplicationController
 
   def search
     params[:id] ||= params[:q]
-    @maps = Map.select("archived, author created_at, description, id, lat, license, location, name, slug, tile_layer, tile_url, tiles, updated_at, user_id, version, zoom").where('archived = ? AND (name LIKE ? OR location LIKE ? OR description LIKE ?)', false, "%"+params[:id]+"%", "%"+params[:id]+"%", "%"+params[:id]+"%").paginate(:page => params[:page], :per_page => 24)
+    @maps = Map.select("archived, author created_at, description, id, lat, license, location, name, slug, tile_layer, tile_url, tiles, updated_at, user_id, version, zoom").where('archived = ? AND (name LIKE ? OR location LIKE ? OR description LIKE ?)', false, "%" + params[:id] + "%", "%" + params[:id] + "%", "%" + params[:id] + "%").paginate(:page => params[:page], :per_page => 24)
     @title = "Search results for '#{params[:id]}'"
     respond_to do |format|
-     format.html { render "maps/index", :layout => "application" } 
-     format.json { render :json => @maps }
+      format.html { render "maps/index", :layout => "application" }
+      format.json { render :json => @maps }
     end
   end
-
 end

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 require 'open3'
 
 class MapsController < ApplicationController
-  protect_from_forgery :except => [:export]
-  before_filter :require_login, :only => [:edit, :update, :destroy]
+  protect_from_forgery except: [:export]
+  before_filter :require_login, only: %i[edit update destroy]
 
   layout 'knitter2'
 
@@ -13,18 +15,18 @@ class MapsController < ApplicationController
                .where(archived: false, password: '')
                .order('updated_at DESC')
                .joins(:warpables)
-               .group("maps.id")
+               .group('maps.id')
     # ensure even maps with no images are shown on front page and don't get lost; some spam risk
     @new_maps = Map.where(archived: false, password: '')
                    .order('updated_at DESC')
-    render :layout => 'application'
+    render layout: 'application'
   end
 
   def map
     @maps = Map.where(archived: false, password: '')
                .select('author, maps.name, lat, lon, slug, archived, password, users.login as user_login')
                .joins(:warpables, :user)
-               .group("maps.id")
+               .group('maps.id')
     render layout: false
   end
 
@@ -39,19 +41,19 @@ class MapsController < ApplicationController
       if @map.save
         redirect_to "/maps/#{@map.slug}"
       else
-        render "new"
+        render 'new'
       end
     else
       @map = Map.new(params[:map])
-      if Rails.env != 'production' || verify_recaptcha(:model => @map, :message => "ReCAPTCHA thinks you're not human! Try again!")
+      if Rails.env != 'production' || verify_recaptcha(model: @map, message: "ReCAPTCHA thinks you're not human! Try again!")
         if @map.save
           redirect_to "/maps/#{@map.slug}"
         else
-          render "new"
+          render 'new'
         end
       else
         @map.errors.add(:base, I18n.t(:wrong_captcha))
-        render "new"
+        render 'new'
       end
     end
   end
@@ -74,9 +76,7 @@ class MapsController < ApplicationController
     @resolution = 5 if @resolution < 5 # soft-set min res
 
     # remove following lines once legacy interface is deprecated
-    if params[:legacy]
-      render :template => 'map/show', :layout => 'knitter'
-    end
+    render template: 'map/show', layout: 'knitter' if params[:legacy]
   end
 
   def archive
@@ -84,12 +84,12 @@ class MapsController < ApplicationController
     if logged_in? && current_user.can_delete?(@map)
       @map.archived = true
       if @map.save
-        flash[:notice] = "Archived map."
+        flash[:notice] = 'Archived map.'
       else
-        flash[:error] = "Failed to archive map."
+        flash[:error] = 'Failed to archive map.'
       end
     else
-      flash[:error] = "Only admins may archive maps."
+      flash[:error] = 'Only admins may archive maps.'
     end
     redirect_to '/?_=' + Time.now.to_i.to_s
   end
@@ -98,7 +98,7 @@ class MapsController < ApplicationController
     @map = Map.find params[:id]
     @map.zoom ||= 12
     @embed = true
-    render :template => 'maps/show'
+    render template: 'maps/show'
   end
 
   def annotate
@@ -122,23 +122,23 @@ class MapsController < ApplicationController
 
     # save new tags
     if params[:tags]
-      params[:tags].gsub(' ', ',').split(',').each do |tagname|
+      params[:tags].tr(' ', ',').split(',').each do |tagname|
         @map.add_tag(tagname.strip, current_user)
       end
     end
 
     @map.save
-    redirect_to :action => "show"
+    redirect_to action: 'show'
   end
 
   def destroy
     @map = Map.find params[:id]
     if current_user.can_delete?(@map)
       @map.destroy
-      flash[:notice] = "Map deleted."
-      redirect_to "/"
+      flash[:notice] = 'Map deleted.'
+      redirect_to '/'
     else
-      flash[:error] = "Only admins or map owners may delete maps."
+      flash[:error] = 'Only admins or map owners may delete maps.'
       redirect_to "/maps/#{@map.slug}"
     end
   end
@@ -153,60 +153,60 @@ class MapsController < ApplicationController
       warpables.last.src = warpable.image.url
       warpables.last.srcmedium = warpable.image.url(:medium)
     end
-    render :json => warpables
+    render json: warpables
   end
 
   # run the export
   def export
     map = Map.find params[:id]
-    if logged_in? || Rails.env.development? || verify_recaptcha(:model => map, :message => "ReCAPTCHA thinks you're not a human!")
-      render :text => map.run_export(current_user, params[:resolution].to_f)
+    if logged_in? || Rails.env.development? || verify_recaptcha(model: map, message: "ReCAPTCHA thinks you're not a human!")
+      render text: map.run_export(current_user, params[:resolution].to_f)
     else
-      render :text => 'You must be logged in to export, unless the map is anonymous.'
+      render text: 'You must be logged in to export, unless the map is anonymous.'
     end
   end
 
   # render list of exports
   def exports
     @map = Map.find params[:id]
-    render :partial => "maps/exports", :layout => false
+    render partial: 'maps/exports', layout: false
   end
 
   # list by region
   def region
-    area = params[:id] || "this area"
+    area = params[:id] || 'this area'
     @title = "Maps in #{area}"
     ids = Map.bbox(params[:minlat], params[:minlon], params[:maxlat], params[:maxlon]).collect(&:id)
-    @maps = Map.where(password: '').where('id IN (?)', ids).paginate(:page => params[:page], :per_page => 24).except(:styles)
+    @maps = Map.where(password: '').where('id IN (?)', ids).paginate(page: params[:page], per_page: 24).except(:styles)
     @maps.each do |map|
       map.image_urls = map.warpables.map { |warpable| warpable.image.url }
     end
     respond_to do |format|
-      format.html { render "maps/index", :layout => "application" }
-      format.json { render :json => @maps.to_json(methods: :image_urls) }
+      format.html { render 'maps/index', layout: 'application' }
+      format.json { render json: @maps.to_json(methods: :image_urls) }
     end
   end
 
   # list by license
   def license
     @title = "Maps licensed '#{params[:id]}'"
-    @maps = Map.where(password: '', license: params[:id]).order('updated_at DESC').paginate(:page => params[:page], :per_page => 24)
-    render "maps/index", :layout => "application"
+    @maps = Map.where(password: '', license: params[:id]).order('updated_at DESC').paginate(page: params[:page], per_page: 24)
+    render 'maps/index', layout: 'application'
   end
 
   def featured
-    @title = "Featured maps"
-    @maps = Map.joins(:warpables).select("maps.*, count(maps.id) as image_count").group("warpables.map_id").order("image_count DESC").paginate(:page => params[:page], :per_page => 24)
-    render "maps/index", :layout => "application"
+    @title = 'Featured maps'
+    @maps = Map.joins(:warpables).select('maps.*, count(maps.id) as image_count').group('warpables.map_id').order('image_count DESC').paginate(page: params[:page], per_page: 24)
+    render 'maps/index', layout: 'application'
   end
 
   def search
     params[:id] ||= params[:q]
-    @maps = Map.select("archived, author created_at, description, id, lat, license, location, name, slug, tile_layer, tile_url, tiles, updated_at, user_id, version, zoom").where('archived = ? AND (name LIKE ? OR location LIKE ? OR description LIKE ?)', false, "%" + params[:id] + "%", "%" + params[:id] + "%", "%" + params[:id] + "%").paginate(:page => params[:page], :per_page => 24)
+    @maps = Map.select('archived, author created_at, description, id, lat, license, location, name, slug, tile_layer, tile_url, tiles, updated_at, user_id, version, zoom').where('archived = ? AND (name LIKE ? OR location LIKE ? OR description LIKE ?)', false, '%' + params[:id] + '%', '%' + params[:id] + '%', '%' + params[:id] + '%').paginate(page: params[:page], per_page: 24)
     @title = "Search results for '#{params[:id]}'"
     respond_to do |format|
-      format.html { render "maps/index", :layout => "application" }
-      format.json { render :json => @maps }
+      format.html { render 'maps/index', layout: 'application' }
+      format.json { render json: @maps }
     end
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,31 +1,31 @@
+# frozen_string_literal: true
+
 require 'uri'
 
-# This controller handles the login/logout function of the site.  
+# This controller handles the login/logout function of the site.
 class SessionsController < ApplicationController
-  #protect_from_forgery :except => [:create]
+  # protect_from_forgery :except => [:create]
 
-  @@openid_url_base  = "https://publiclab.org/people/"
-  @@openid_url_suffix = "/identity"
+  @@openid_url_base = 'https://publiclab.org/people/'
+  @@openid_url_suffix = '/identity'
 
   # render new.erb.html
-  def new #login
+  def new # login
     if logged_in?
-      redirect_to "/"
+      redirect_to '/'
     else
-      @referer = params[:back_to]  
+      @referer = params[:back_to]
     end
   end
 
-  def create #new
+  def create # new
     back_to = params[:back_to]
     open_id = params[:open_id]
     openid_url = URI.decode(open_id)
-    #possibly user is providing the whole URL
-    if openid_url.include? "publiclab"
-      if openid_url.include? "http"
-        url = openid_url
-      end
-    else 
+    # possibly user is providing the whole URL
+    if openid_url.include? 'publiclab'
+      url = openid_url if openid_url.include? 'http'
+    else
       url = @@openid_url_base + openid_url + @@openid_url_suffix
     end
     openid_authentication(url, back_to)
@@ -34,27 +34,27 @@ class SessionsController < ApplicationController
   # only on local installations, to bypass OpenID; add "local: true" to config/config.yml
   # this makes offline development possible; like on a plane! but do NOT leave it open on a production machine
   def local
-    if APP_CONFIG["local"] == true && @current_user = User.find_by_login(params[:login])
-      successful_login '', nil 
+    if APP_CONFIG['local'] == true && @current_user = User.find_by_login(params[:login])
+      successful_login '', nil
     else
-      flash[:error] = "Forbidden"
-      redirect_to "/"
+      flash[:error] = 'Forbidden'
+      redirect_to '/'
     end
   end
 
-  def failed_login(message = "Authentication failed.")
+  def failed_login(message = 'Authentication failed.')
     flash[:danger] = message
     redirect_to '/'
   end
 
   def successful_login(back_to, id)
     session[:user_id] = @current_user.id
-    flash[:success] = "You have successfully logged in."
+    flash[:success] = 'You have successfully logged in.'
     if id
       redirect_to '/sites/' + id.to_s + '/upload'
     else
-      if back_to 
-        redirect_to back_to 
+      if back_to
+        redirect_to back_to
       else
         redirect_to '/sites'
       end
@@ -62,37 +62,37 @@ class SessionsController < ApplicationController
   end
 
   def logout
-    session[:user_id] = nil 
-    flash[:success] = "You have successfully logged out."
+    session[:user_id] = nil
+    flash[:success] = 'You have successfully logged out.'
     redirect_to '/' + '?_=' + Time.now.to_i.to_s
   end
 
   protected
 
   def openid_authentication(openid_url, back_to)
-    #puts openid_url
-    authenticate_with_open_id(openid_url, :required => [:nickname, :email]) do |result, identity_url, registration|
+    # puts openid_url
+    authenticate_with_open_id(openid_url, required: %i[nickname email]) do |result, identity_url, registration|
       if result.successful?
         @user = User.find_by_identity_url(identity_url)
-        if not @user
+        unless @user
           @user = User.new
           @user.login = registration['nickname']
           @user.email = registration['email']
           @user.identity_url = identity_url
-          begin 
+          begin
             @user.save!
           rescue ActiveRecord::RecordInvalid => invalid
             puts invalid
-            failed_login "User can not be associated to local account. Probably the account already exists with different capitalization!" 
+            failed_login 'User can not be associated to local account. Probably the account already exists with different capitalization!'
             return
           end
         end
         nonce = params[:n]
-        if nonce 
+        if nonce
           tmp = Sitetmp.find_by nonce: nonce
-          if tmp 
+          if tmp
             data = tmp.attributes
-            data.delete("nonce")
+            data.delete('nonce')
             site = Site.new(data)
             site.save
             tmp.destroy
@@ -102,7 +102,7 @@ class SessionsController < ApplicationController
         if site
           successful_login back_to, site.id
         else
-          successful_login back_to, nil 
+          successful_login back_to, nil
         end
       else
         failed_login result.message
@@ -110,5 +110,4 @@ class SessionsController < ApplicationController
       end
     end
   end
-
 end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,6 +1,7 @@
-class TagsController < ApplicationController
+# frozen_string_literal: true
 
-  before_filter :require_login, :only => [:edit, :update, :destroy]
+class TagsController < ApplicationController
+  before_filter :require_login, only: %i[edit update destroy]
 
   def create
     @map = Map.find params[:map_id]
@@ -8,39 +9,38 @@ class TagsController < ApplicationController
     if logged_in?
       # there is identical code in MapsController#update.
       # TODO: DRY up this functionality.
- 
+
       # save new tags
       if params[:tags]
-        params[:tags].gsub(' ', ',').split(',').each do |tagname|
+        params[:tags].tr(' ', ',').split(',').each do |tagname|
           @map.add_tag(tagname.strip, current_user)
         end
       end
- 
-      redirect_to "/maps/" + @map.slug
+
+      redirect_to '/maps/' + @map.slug
     else
-      flash[:error] = "You must be logged in to add tags"
-      redirect_to "/login?back_to=/maps/" + @map.slug
+      flash[:error] = 'You must be logged in to add tags'
+      redirect_to '/login?back_to=/maps/' + @map.slug
     end
   end
 
   def show
     @tag = Tag.find_by_name params[:id]
-    @maps = @tag.maps.paginate(:page => params[:page], :per_page => 24)
-    @title = "Maps tagged with '"+@tag.name+"'"
-    render :template => 'maps/index'
+    @maps = @tag.maps.paginate(page: params[:page], per_page: 24)
+    @title = "Maps tagged with '" + @tag.name + "'"
+    render template: 'maps/index'
   end
 
   def destroy
     @tag = Tag.find(params[:id])
 
-    if logged_in? && (@tag.user_id.to_i == current_user.id || current_user.role == "admin")
+    if logged_in? && (@tag.user_id.to_i == current_user.id || current_user.role == 'admin')
       @tag.delete
-      flash[:notice] = "Tag " + @tag.name + " deleted."
+      flash[:notice] = 'Tag ' + @tag.name + ' deleted.'
       redirect_to @tag.map
     else
-      flash[:error] = "You must be logged in to delete tags."
-      redirect_to "/login"
+      flash[:error] = 'You must be logged in to delete tags.'
+      redirect_to '/login'
     end
   end
-
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,20 +1,20 @@
-class UsersController < ApplicationController
+# frozen_string_literal: true
 
+class UsersController < ApplicationController
   def profile
     params[:id] = current_user.login if logged_in? && params[:id] == 0
     @user = User.find_by_login(params[:id])
     @maps = Map.where(user_id: @user.id)
-      .paginate(:page => params[:page], :per_page => 24)
+               .paginate(page: params[:page], per_page: 24)
   end
 
   def index
-    @title = "Prolific map authors"
+    @title = 'Prolific map authors'
     @users = User.joins(:maps)
-      .select("users.*, count(users.id) as maps_count")
-      .group("maps.user_id")
-      .order("maps_count DESC")
-      .paginate(:page => params[:page], :per_page => 24)
-    render "users/index"
+                 .select('users.*, count(users.id) as maps_count')
+                 .group('maps.user_id')
+                 .order('maps_count DESC')
+                 .paginate(page: params[:page], per_page: 24)
+    render 'users/index'
   end
-
 end

--- a/app/controllers/utility_controller.rb
+++ b/app/controllers/utility_controller.rb
@@ -1,12 +1,12 @@
-class UtilityController < ApplicationController
+# frozen_string_literal: true
 
+class UtilityController < ApplicationController
   # translates TMS formats from one ordering to another
   def tms_alt
     # /z/x/y.png
     # /z/x/y.png
     # /z/x/(2*z-y-1).png
-    y = 2**params[:z].to_i-params[:y].to_i-1
+    y = 2**params[:z].to_i - params[:y].to_i - 1
     redirect_to "/tms/#{params[:id]}/#{params[:z]}/#{params[:x]}/#{y}.png"
   end
-
 end


### PR DESCRIPTION
Part of #533 
I have fixed ~400 rubocop issues using rubocop's auto correct feature.
Most of the changes include indentation fixes and using the new hash syntax.
A lot of offenses can be fixed automatically. For the ones that cannot, perhaps we can open FTOs? 
