### PR TITLE
Solve image uploads bugs

### DIFF
--- a/app/views/images/_new.html.erb
+++ b/app/views/images/_new.html.erb
@@ -1,4 +1,4 @@
-<div class="modal fade" id="uploadModal" tabindex="-1" role="dialog" aria-labelledby="uploadModalLabel" aria-hidden="true">
+<div class="modal fade show" id="uploadModal" tabindex="-1" role="dialog" aria-labelledby="uploadModalLabel" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
@@ -32,8 +32,8 @@
 
           <script id="template-upload" type="text/x-tmpl">
           {% for (var i=0, file; file=o.files[i]; i++) { %}
-            <tr class="template-upload fade">
-              <td class="preview"><span class="fade"></span></td>
+            <tr class="template-upload fade show">
+              <td class="preview"><span class="fade show"></span></td>
               <td class="name"><span>{%=file.name%}</span></td>
               <td class="status"><i class="fa fa-spinner fa-spin"></i> Uploading... </td>
               <td class="size"><span>{%=o.formatFileSize(file.size)%}</span></td>
@@ -65,7 +65,7 @@
           <!-- The template to display files available for download -->
           <script id="template-download" type="text/x-tmpl">
             {% for (var i=0, file; file=o.files[i]; i++) { %}
-              <tr class="template-download fade" id="warpable-{%= file.id %}">
+              <tr class="template-download fade show" id="warpable-{%= file.id %}">
                 {% if (file.error) { %}
                   <td></td>
                   <td class="name"><span>{%=file.name%}</span></td>


### PR DESCRIPTION
Fixes #407,  #257 and #549
Add .show class after fade
In bootstrap4 first tab pane must have .show to make the initial content visible

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/reviewers` for help, in a comment below
