### PR TITLE
Fix map loading

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,7 +11,6 @@
 // GO AFTER THE REQUIRES BELOW.
 //
 
-//= require_tree .
 //= require jquery
 //= require jquery-ujs
 //= require jquery/dist/jquery.js
@@ -24,8 +23,8 @@
 //= require leaflet-toolbar/dist/leaflet.toolbar.js
 //= require leaflet-distortableimage/dist/leaflet.distortableimage.js
 //= require leaflet-easybutton/src/easy-button.js
-//= require Google.js
 //= require sparklines/source/sparkline.js
 //= require annotations-legacy.js
 //= require glfx-js/dist/glfx.js
 //= require webgl-distort/dist/webgl-distort.js
+//= require_tree .


### PR DESCRIPTION
Fixes #728 

Hi here is the solution in case someone else faces this issue later
` //= require_tree .` loads all the custom .js from the folder `app/assets/javascripts/`
Since it was at the top of the declarations, the custom js was loaded first.
Because of this,  `Google.js` was loaded before `leaflet` which gave rise to the error `L is not defined `
So be careful about the order in which you're loading the static files!
Thanks!