### PR TITLE
Exclude .idea directory from tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ coverage_report/
 test/reports/*
 yarn-error.log
 yarn.lock
+.idea/


### PR DESCRIPTION
IntelliJ IDEs add .idea/ directory to the project so one has to be careful while making a commit, so adding it in gitignore. Although, some of the .idea/ files can be tracked by VCS but let's ignore it for now. 

