### PR TITLE
Refactored with #replaceTool and fixed `Delete` error

### DIFF
--- a/app/assets/javascripts/mapknitter/Map.js
+++ b/app/assets/javascripts/mapknitter/Map.js
@@ -159,8 +159,13 @@ MapKnitter.Map = MapKnitter.Class.extend({
 
     // overriding the upstream Delete action so that it makes database updates in MapKnitter
     L.DomEvent.on(img._image, 'load', function() {
-      if (edit.hasTool(Delete)) { edit.removeTool(Delete); }
-      edit.addTool(mapknitter.customDeleteAction());
+      var newTool = mapknitter.customDeleteAction();
+
+      if (edit.hasTool(L.DeleteAction)) { 
+        edit.replaceTool(L.DeleteAction, newTool); 
+      } else {
+        edit.addTool(newTool);
+      }
 
       if (!edit._selected) { edit._deselect(); }
 


### PR DESCRIPTION
Fixes part 2 of https://github.com/publiclab/Leaflet.DistortableImage/issues/367 and error from https://github.com/publiclab/mapknitter/issues/1124

I refactored the code to use the new `#replaceTool` function.  I also replaced the variable name `Delete` with `L.DeleteAction` to fix the error in https://github.com/publiclab/mapknitter/issues/1124. 

@gauravano @SidharthBansal @sashadev-sky @IshaGupta18 @cesswairimu @divyabaid16 @jywarren Could you take a look please? Thanks!
