### PR TITLE
ADD: Recaptcha warning message

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -2,6 +2,11 @@
 
 pidfile=/app/tmp/pids/server.pid
 
+if [ ! -f "./config/initializers/recaptcha.rb" ]; then
+    echo -e "\e[33mWARNING\e[0m: You haven't configured recaptcha!"
+    echo -e "\e[94mRead More\e[0m: https://github.com/publiclab/mapknitter#installation-steps"
+fi
+
 bump_database(){
 	bundle exec rails db:schema:load || bundle exec rails db:migrate
 }


### PR DESCRIPTION
A user had complained about us not showing a warning when recaptcha is
not configured. This change introduces a warning for users that haven't
configured recaptcha.

![msg](https://user-images.githubusercontent.com/35997844/71328825-973f2a80-251d-11ea-9a9b-209e99d3ee33.png)

Resolves #1112

@cesswairimu @sidntrivedi012 @sashadev-sky  could you review this, please?
Thanks.