### PR TITLE
fix footer width problem

### DIFF
--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -148,8 +148,6 @@ label small {
   padding: 30px 60px 40px;
   border-top: 1px solid #ddd;
   background:#f6f9fc;
-  width: 80%;
-
 }
 
 .footer .footer-link {


### PR DESCRIPTION
After #1152, I for some reason restricted the width of the footer to 80% and @tsparksh warned me that it now looks like this:

> ![image](https://user-images.githubusercontent.com/17945250/71669000-ce270300-2d9d-11ea-85a0-8303e3930094.png)

So this pull request is just to remove that css rule so the footer is once again at max width
