### PR TITLE
Add limit to avoid core dump file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - ../dump:/docker-entrypoint-initdb.d
   web:
     build: .
+    ulimits:
+      core: 0
     env_file:
       - mapknitter.env
     volumes:


### PR DESCRIPTION
Fixes #1208

This is supposed to avoid creation of a ./core file when passenger crashes. It is not a solution to the actual crash but it should avoid breaking the staging build. I will try it on top of current `unstable` first.

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

[//]: # (To mark checkbox write 'x' within the square brackets)

* [ ] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [ ] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/mapknitter-reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
