### PR TITLE
Rectify login page styling

### DIFF
--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -318,7 +318,7 @@ label small {
   }
 }
 
-.container{
+.container#login_mk {
   padding-top: 2.5%;
   text-align: center;
 }

--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -317,3 +317,7 @@ label small {
     width: 100%
   }
 }
+.container{
+  padding-top: 2.5%;
+  text-align: center;
+}

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="container" id="login_mk">
     <h1>Log In</h1>
     <%= render :partial => "layouts/login_form" %>
 </div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,6 +1,4 @@
 <div class="container">
-  <div class="col-md-5">
     <h1>Log In</h1>
     <%= render :partial => "layouts/login_form" %>
-  </div>
 </div>


### PR DESCRIPTION
Fixes #1183 (<=== Add issue number here)
Adds padding and allignment for contents on the login page
![Screenshot from 2020-02-05 18-35-18](https://user-images.githubusercontent.com/53974118/73844325-5fc6dc00-4846-11ea-9b1c-8925b5c517a1.png)


Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

[//]: # (To mark checkbox write 'x' within the square brackets)

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/mapknitter-reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!