### PR TITLE
Update application.rb

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -46,6 +46,7 @@ module Mapknitter
     config.assets.enabled = true
 
     config.action_dispatch.default_headers['X-Frame-Options'] = "ALLOW-FROM https://publiclab.org"
+    config.action_dispatch.default_headers['Access-Control-Allow-Origin'] = "*"
 
     # Version of your assets, change this if you want to expire all your assets
     config.assets.paths << Rails.root.join("public","lib")


### PR DESCRIPTION
based on https://github.com/publiclab/mapknitter/pull/839/ and not https://github.com/publiclab/mapknitter/pull/849

allows access to https://mapknitter.org/map/region/Gulf-Coast.json?minlon=-91.79763793945314&minlat=29.016547110420984&maxlon=-90.10711669921875&maxlat=29.951364951739354 from publiclab.org and other servers