### PR TITLE
Fix trailing comma, altered headers. (Fixes CORS)

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -46,7 +46,7 @@ module Mapknitter
     config.assets.enabled = true
 
     config.action_dispatch.default_headers['X-Frame-Options'] = "ALLOW-FROM https://publiclab.org"
-    config.action_dispatch.default_headers['Access-Control-Allow-Origin'] = 'https://publiclab.org',
+    config.action_dispatch.default_headers['Access-Control-Allow-Origin'] = 'https://publiclab.org'
     config.action_dispatch.default_headers['Access-Control-Request-Method'] = 'GET' 
 
     # Version of your assets, change this if you want to expire all your assets


### PR DESCRIPTION
This was a tricky one. Ruby interpreted a trailing comma that I sloppily left behind as meaning to concatenate with the next assigned variable (!). Giving the wrong headers for CORS.

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

[//]: # (To mark checkbox write 'x' within the square brackets)

* [ ] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [ ] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updation
* [ ] ask `@publiclab/mapknitter-reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
