### PR TITLE
Add message if no maps available

### DIFF
--- a/app/views/front_ui/_maps.html.erb
+++ b/app/views/front_ui/_maps.html.erb
@@ -1,4 +1,11 @@
 <div class="row map-list mx-auto">
+  <% if maps.length == 0 %>
+    <div style="display:flex;flex-direction:column;align-items:center;width:100%"> 
+      <i class="fas fa-search fa-5x" style="size:100px;line-height:100px;padding:20px;border-radius:20px;color:#343a40;background-color:#dfdfdf;"></i></br>
+      <h4>No results found</h4>
+      <a href="/gallery"> See our featured maps </a>
+    </div>
+  <% end %>
   <% maps.each do |map| %>
       <% warp = map.placed_warpables.first %>
     <div class="card-deck map col-md-6 col-lg-3 col-xs-12 mb-2 ml-2">


### PR DESCRIPTION
Fixes #1182 

Added a "No results found" message wherever we are displaying map lists and no results are available. 

![noresults1](https://user-images.githubusercontent.com/85152262/158049583-dba189b3-bdd3-45e9-ae16-a3c49b27dd71.png)

![noresults2](https://user-images.githubusercontent.com/85152262/158049719-ded393f2-3abb-43f4-9c85-f19c71b554ee.png)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

[//]: # (To mark checkbox write 'x' within the square brackets)

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/mapknitter-reviewers` for help, in a comment below
