### PR TITLE
Remove navbar overlap

### DIFF
--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -1,5 +1,4 @@
 body {
-  padding-top:55px;
   overflow-x: hidden;
 }
 

--- a/app/views/layouts/_alerts.html.erb
+++ b/app/views/layouts/_alerts.html.erb
@@ -1,12 +1,12 @@
 <div class="container-fluid" id="alerts">
   <% flash.each do |key, value| %> 
     <% if key == :notice %>
-      <div class="alert alert-success">
+      <div class="alert alert-success mt-3">
         <button type="button" class="close" data-dismiss="alert">
           <i class="fa fa-close"></i></button><%= value %>
       </div>
     <% else %>
-      <div class="alert alert-<%= key %>">
+      <div class="alert alert-<%= key %> mt-3">
         <button type="button" class="close" data-dismiss="alert">
           <i class="fa fa-close"></i></button><%= value %>
       </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,4 +1,4 @@
-<nav class="navbar fixed-top navbar-expand-lg navbar-dark bg-dark">
+<nav class="navbar static-top navbar-expand-lg navbar-dark bg-dark">
   <a class="navbar-brand" href="/">MapKnitter</a>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#header-navbar-collapse" aria-controls="header-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>

--- a/app/views/layouts/knitter2.html.erb
+++ b/app/views/layouts/knitter2.html.erb
@@ -19,6 +19,8 @@
 </head>
 <body>
 
+  <%= render :partial => 'layouts/header' %>
+
   <div class="modal modal-welcome">
     <div class="modal-dialog">
       <div class="modal-content">
@@ -59,7 +61,6 @@
 
   <% unless @embed %>
   <div class="sidebar">
-    <%= render :partial => 'layouts/header' %>
     <div class="sidebar-wrap">
       <div class="sidebar-inner-wrap">
         <div class="sidebar-header"><%= yield :title %></div> <% if @map.new_record? %>


### PR DESCRIPTION
Fixes #1611  (<=== Add issue number here)

Changed navbar bootstrap class so that it does not overlap with site content, specially notifications.

Before ->

https://user-images.githubusercontent.com/85152262/158656373-25490865-e83d-4762-b30c-6c6cea669368.mp4

After ->

https://user-images.githubusercontent.com/85152262/158656600-b8a488ac-dcb2-4fdb-85ff-df41f9f852fb.mp4

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

[//]: # (To mark checkbox write 'x' within the square brackets)

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/mapknitter-reviewers` for help, in a comment below
