### PR TITLE
Adjust overflowing text in featured places

### DIFF
--- a/app/assets/stylesheets/front_ui.scss
+++ b/app/assets/stylesheets/front_ui.scss
@@ -17,13 +17,6 @@
   .featured-places a {
     padding: 8px 12px;
   }
-  .featured-places {
-    text-align: center;
-    padding-bottom: 20px;
-    width: 100%;
-    overflow: hidden;
-    position: absolute;
-  }
   #anonymous-map button{
     width: 70px;
     background-color: #ffffff;

--- a/app/views/front_ui/index.html.erb
+++ b/app/views/front_ui/index.html.erb
@@ -49,7 +49,7 @@
 <div id="mapknitter-unique" class="mx-auto" style="height: 450px; width: 100%;"></div>
 
 <div style="padding:5px;">
-  <div class="featured-places">
+  <div class="row justify-content-center featured-places ml-2 mr-2">
     <!-- <%= link_to 'Nearby Maps', 'front_ui/nearby_mappers' %> -->
   </div>
 </div>


### PR DESCRIPTION
Fixes #1653 

Adjusted the overflowing text in featured places on the home page.

Before -

https://user-images.githubusercontent.com/85152262/163663161-bf9cbab3-db20-4393-b601-5104df580ee9.mp4

After -

https://user-images.githubusercontent.com/85152262/163663170-91777223-d19d-404b-9532-da50dabc1e22.mp4

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/mapknitter-reviewers` for help, in a comment below
