### PR TITLE
Responsive error of About Page 

### DIFF
--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -41,6 +41,10 @@ body {
 }
 
 @media(max-width: 992px) {
+  #about-img {
+    margin: 20px auto;
+    width: -webkit-fill-available;
+  }  
   .navbar-nav .navbar-form {
     margin-top: 10px;
   }

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -43,7 +43,7 @@ body {
 @media(max-width: 992px) {
   #about-img {
     margin: 20px auto;
-    width: -webkit-fill-available;
+    min-width: 100%;
   }  
   .navbar-nav .navbar-form {
     margin-top: 10px;


### PR DESCRIPTION
Fixes #1656  (<=== Add issue number here)
**Problem**
The About Page of Mapknitter is not responsive according to screen resolution


### Relevant URLs

https://https://mapknitter.org/about

**Before**

https://user-images.githubusercontent.com/67657066/163668837-ed91ebe9-8cb5-4222-98fe-aaad25edddf6.mp4





**After**-->


https://user-images.githubusercontent.com/67657066/163668852-4f799137-115d-4ddf-93f5-01f1e3183207.mp4



Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

[//]: # (To mark checkbox write 'x' within the square brackets)

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updation
* [x] ask `@publiclab/mapknitter-reviewers` for help, in a comment below

